### PR TITLE
Support `xtensor` arrays in LC

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,6 +67,8 @@ jobs:
 
             lc tests/array_02.cpp --backend=llvm --extra-arg="-Isrc/runtime/include" --
 
+            lc tests/array_03.cpp --backend=llvm --
+
             # Test generating object files
             lc examples/expr2.c --backend c --extra-arg="-Isrc/runtime/include" -o c_o -c --
             lc examples/expr2.c --backend llvm --extra-arg="-Isrc/runtime/include" -o llvm_o -c --

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
 
             lc tests/array_02.cpp --backend=llvm --extra-arg="-Isrc/runtime/include" --
 
-            lc tests/array_03.cpp --backend=llvm --
+            lc tests/array_03.cpp --backend=llvm --extra-arg="-I$CONDA_PREFIX/include" --
 
             # Test generating object files
             lc examples/expr2.c --backend c --extra-arg="-Isrc/runtime/include" -o c_o -c --

--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -11,3 +11,4 @@ dependencies:
   - git=2.43.0
   - python=3.12.0
   - toml=0.10.2
+  - xtensor=0.24.7

--- a/src/lc/clang_ast_to_asr.h
+++ b/src/lc/clang_ast_to_asr.h
@@ -898,6 +898,9 @@ public:
             "include/__stddef_max_align_t.h",
             "usr/include",
             "mambaforge/envs",
+            "lib/gcc",
+            "lib/clang",
+            "micromamba-root/envs"
         };
         for( std::string& path: include_paths ) {
             if( file_path.find(path) != std::string::npos ) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9231,6 +9231,7 @@ Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
         v.module->print(os, nullptr);
         std::cout << os.str();
         msg = "asr_to_llvm: module failed verification. Error:\n" + err.str();
+        std::cout << msg << std::endl;
         diagnostics.diagnostics.push_back(diag::Diagnostic(msg,
             diag::Level::Error, diag::Stage::CodeGen));
         Error error;

--- a/tests/array_03.cpp
+++ b/tests/array_03.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+#include "xtensor/xtensor.hpp"
+#include "xtensor/xio.hpp"
+#include "xtensor/xview.hpp"
+
+int main() {
+
+    xt::xtensor<double, 2> arr1; /* { // TODO: Uncomment this initializer
+      {1.0, 2.0, 3.0},
+      {2.0, 5.0, 7.0},
+      {2.0, 5.0, 7.0}}; */
+
+    xt::xtensor<double, 1> arr2 {5.0, 6.0, 7.0};
+
+    // xt::xarray<double> res = xt::view(arr1, 1) + arr2; // TODO: Uncomment this statement
+    std::cout << arr2;
+
+    return 0;
+}

--- a/tests/reference/asr-array_02-0507073.json
+++ b/tests/reference/asr-array_02-0507073.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_02-0507073.stdout",
-    "stdout_hash": "0baf3d16bb054881ea07f3b263006e49d1cbbad16dafe435cbd78e35",
+    "stdout_hash": "330d65993b5445881264552aaa9b7415b7be4a04a3ec05f5b8ae3d92",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_02-0507073.stdout
+++ b/tests/reference/asr-array_02-0507073.stdout
@@ -32,7 +32,7 @@
                                     ()
                                     ()
                                     Default
-                                    (Real 4)
+                                    (Real 8)
                                     ()
                                     Source
                                     Public
@@ -65,7 +65,7 @@
                             [((IntegerConstant 4 (Integer 4)))
                             ((IntegerConstant 10 (Integer 4)))
                             ((IntegerConstant 4 (Integer 4)))]
-                            (Real 4)
+                            (Real 8)
                             ()
                             ()
                         )
@@ -75,7 +75,7 @@
                         [(Cast
                             (Var 4 sum)
                             RealToReal
-                            (Real 4)
+                            (Real 8)
                             ()
                         )]
                         ()
@@ -144,7 +144,7 @@
                                     ()
                                     ()
                                     Default
-                                    (Real 4)
+                                    (Real 8)
                                     ()
                                     Source
                                     Public
@@ -161,7 +161,7 @@
                                     ()
                                     Default
                                     (Array
-                                        (Real 4)
+                                        (Real 8)
                                         [((IntegerConstant 0 (Integer 4))
                                         (Var 3 n))]
                                         PointerToDataArray
@@ -182,7 +182,7 @@
                                     ()
                                     Default
                                     (Array
-                                        (Real 4)
+                                        (Real 8)
                                         [((IntegerConstant 0 (Integer 4))
                                         (Var 3 nums))
                                         ((IntegerConstant 0 (Integer 4))
@@ -366,7 +366,7 @@
                                     ()
                                     ()
                                     Default
-                                    (Real 4)
+                                    (Real 8)
                                     ()
                                     Source
                                     Public
@@ -382,7 +382,7 @@
                                     ()
                                     ()
                                     Default
-                                    (Real 4)
+                                    (Real 8)
                                     ()
                                     Source
                                     Public
@@ -395,7 +395,7 @@
                         [(Integer 4)
                         (Integer 4)
                         (Integer 4)]
-                        (Real 4)
+                        (Real 8)
                         Source
                         Implementation
                         ()
@@ -465,7 +465,7 @@
                                         (()
                                         (Var 3 j)
                                         ())]
-                                        (Real 4)
+                                        (Real 8)
                                         RowMajor
                                         ()
                                     )
@@ -479,7 +479,7 @@
                                                 ()
                                             )
                                             IntegerToReal
-                                            (Real 4)
+                                            (Real 8)
                                             ()
                                         )
                                         Div
@@ -492,10 +492,10 @@
                                                 ()
                                             )
                                             IntegerToReal
-                                            (Real 4)
+                                            (Real 8)
                                             ()
                                         )
-                                        (Real 4)
+                                        (Real 8)
                                         ()
                                     )
                                     ()
@@ -556,7 +556,7 @@
                                 [(()
                                 (Var 3 k)
                                 ())]
-                                (Real 4)
+                                (Real 8)
                                 RowMajor
                                 ()
                             )
@@ -564,17 +564,17 @@
                                 (Cast
                                     (Var 3 k)
                                     IntegerToReal
-                                    (Real 4)
+                                    (Real 8)
                                     ()
                                 )
                                 Div
                                 (Cast
                                     (Var 3 n)
                                     IntegerToReal
-                                    (Real 4)
+                                    (Real 8)
                                     ()
                                 )
-                                (Real 4)
+                                (Real 8)
                                 ()
                             )
                             ()
@@ -599,7 +599,7 @@
                                 (Real 8)
                             )
                             RealToReal
-                            (Real 4)
+                            (Real 8)
                             ()
                         )
                         ()
@@ -640,7 +640,7 @@
                                         (Real 8)
                                     )
                                     RealToReal
-                                    (Real 4)
+                                    (Real 8)
                                     ()
                                 )
                                 ()
@@ -676,7 +676,7 @@
                                                 (()
                                                 (Var 3 j1)
                                                 ())]
-                                                (Real 4)
+                                                (Real 8)
                                                 RowMajor
                                                 ()
                                             )
@@ -686,14 +686,14 @@
                                                 [(()
                                                 (Var 3 j1)
                                                 ())]
-                                                (Real 4)
+                                                (Real 8)
                                                 RowMajor
                                                 ()
                                             )
-                                            (Real 4)
+                                            (Real 8)
                                             ()
                                         )
-                                        (Real 4)
+                                        (Real 8)
                                         ()
                                     )
                                     ()
@@ -716,7 +716,7 @@
                                     (Var 3 sum)
                                     Add
                                     (Var 3 output)
-                                    (Real 4)
+                                    (Real 8)
                                     ()
                                 )
                                 ()


### PR DESCRIPTION
https://github.com/lcompilers/lc/issues/12

Test I am working on,

```cpp
#include <iostream>
#include "xtensor/xarray.hpp"
#include "xtensor/xio.hpp"
#include "xtensor/xview.hpp"

int main() {

    xt::xarray<double> arr1 {
      {1.0, 2.0, 3.0},
      {2.0, 5.0, 7.0},
      {2.0, 5.0, 7.0}};

    xt::xarray<double> arr2 {5.0, 6.0, 7.0};

    xt::xarray<double> res = xt::view(arr1, 1) + arr2;
    std::cout << res;

    return 0;
}
```