### PR TITLE
Reset `tmp` to `nullptr` everytime its used to avoid using corrupt values

### DIFF
--- a/integration_tests/array_08.cpp
+++ b/integration_tests/array_08.cpp
@@ -23,6 +23,10 @@ int main() {
     xt::xtensor<double, 2> a = xt::empty<double>({3, 2});
     xt::xtensor<double, 2> b = xt::empty<double>({2, 3});
     xt::xtensor<double, 2> c = xt::empty<double>({3, 3});
+    xt::xtensor<double, 2> ce = {
+        {0.0, 0.0, 0.0},
+        {0.0, 6.0, 12.0},
+        {0.0, 12.0, 24.0}};
 
     for( int i = 0; i < a.shape(0); i++ ) {
         for( int j = 0; j < a.shape(1); j++ ) {
@@ -39,6 +43,13 @@ int main() {
     std::cout << a << b << std::endl;
     c = matmul(a, b);
     std::cout << c << std::endl;
+    for( int i = 0; i < c.shape(0); i++ ) {
+        for( int j = 0; j < c.shape(1); j++ ) {
+            if( c(i, j) != ce(i, j) ) {
+                exit(2);
+            }
+        }
+    }
 
     return 0;
 }

--- a/tests/reference/asr-array_01-1c98579.json
+++ b/tests/reference/asr-array_01-1c98579.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_01-1c98579.stdout",
-    "stdout_hash": "39e2651bf0ba48fe08ff167a6def7c7c94bbb6dbb498b995aa00ea48",
+    "stdout_hash": "337b11bab91bf64e841d76a62768573e77f7b5b2db440edef9ad10e7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_01-1c98579.stdout
+++ b/tests/reference/asr-array_01-1c98579.stdout
@@ -295,7 +295,7 @@
                             (Var 2 i)
                             Lt
                             (IntegerConstant 5 (Integer 4))
-                            (Integer 4)
+                            (Logical 4)
                             ()
                         )
                         [(=
@@ -340,7 +340,7 @@
                             (Var 2 j)
                             Lt
                             (IntegerConstant 4 (Integer 4))
-                            (Integer 4)
+                            (Logical 4)
                             ()
                         )
                         [(=
@@ -354,7 +354,7 @@
                                 (Var 2 k)
                                 Lt
                                 (IntegerConstant 3 (Integer 4))
-                                (Integer 4)
+                                (Logical 4)
                                 ()
                             )
                             [(=
@@ -368,7 +368,7 @@
                                     (Var 2 l)
                                     Lt
                                     (IntegerConstant 2 (Integer 4))
-                                    (Integer 4)
+                                    (Logical 4)
                                     ()
                                 )
                                 [(=

--- a/tests/reference/asr-array_02-038b0ce.json
+++ b/tests/reference/asr-array_02-038b0ce.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_02-038b0ce.stdout",
-    "stdout_hash": "4e21cea7e6fe96415c34a8b37dd576158110f052e081365f79a648ba",
+    "stdout_hash": "be1e2e3174f008918af1f48265f78ff96e7fe5bd39cb3331be787e64",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_02-038b0ce.stdout
+++ b/tests/reference/asr-array_02-038b0ce.stdout
@@ -422,7 +422,7 @@
                             (Var 2 num)
                             Lt
                             (Var 2 nums)
-                            (Integer 4)
+                            (Logical 4)
                             ()
                         )
                         [(=
@@ -436,7 +436,7 @@
                                 (Var 2 i)
                                 Lt
                                 (Var 2 m)
-                                (Integer 4)
+                                (Logical 4)
                                 ()
                             )
                             [(=
@@ -450,7 +450,7 @@
                                     (Var 2 j)
                                     Lt
                                     (Var 2 n)
-                                    (Integer 4)
+                                    (Logical 4)
                                     ()
                                 )
                                 [(=
@@ -547,7 +547,7 @@
                             (Var 2 k)
                             Lt
                             (Var 2 n)
-                            (Integer 4)
+                            (Logical 4)
                             ()
                         )
                         [(=
@@ -615,7 +615,7 @@
                             (Var 2 num1)
                             Lt
                             (Var 2 nums)
-                            (Integer 4)
+                            (Logical 4)
                             ()
                         )
                         [(=
@@ -629,7 +629,7 @@
                                 (Var 2 i1)
                                 Lt
                                 (IntegerConstant 4 (Integer 4))
-                                (Integer 4)
+                                (Logical 4)
                                 ()
                             )
                             [(=
@@ -656,7 +656,7 @@
                                     (Var 2 j1)
                                     Lt
                                     (IntegerConstant 10 (Integer 4))
-                                    (Integer 4)
+                                    (Logical 4)
                                     ()
                                 )
                                 [(=


### PR DESCRIPTION
Achieved using `OneTimeUseASRNode<T>` for resetting value once read. Helps in avoiding usage of corrupt values generated from previous statements, expressions by making sure whenever `get` is called the `tmp.node` sets to `nullptr`. That way whenever we analyse the next expression/statement `tmp.node` is `nullptr`, so we will start afresh and won't be able to use anything from previous expression/statement even by mistake.

Addition of this uncovered a bug which I fixed in this PR itself.