### PR TITLE
Prohibit modification of `std::vector` objects used by `Kokkos::mdspan` constructor

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,11 @@ jobs:
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         run: |
             export CPATH=$CONDA_PREFIX/include:$CPATH
+            git clone https://github.com/czgdp1807/mdspan
+            cd mdspan
+            cmake . -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+            make install
+            cd ..
             lc --show-clang-ast tests/test.cpp
             lc --show-clang-ast --parse-all-comments tests/parse_comments_01.cpp > parse_comments_01.stdout
             grep "TextComment" parse_comments_01.stdout
@@ -76,10 +81,5 @@ jobs:
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         run: |
             export CPATH=$CONDA_PREFIX/include:$CPATH
-            git clone https://github.com/czgdp1807/mdspan
-            cd mdspan
-            cmake . -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
-            make install
-            cd ..
             ./integration_tests/run_tests.py -b gcc llvm wasm c
             ./integration_tests/run_tests.py -b gcc llvm wasm c -f

--- a/src/lc/clang_ast_to_asr.cpp
+++ b/src/lc/clang_ast_to_asr.cpp
@@ -2258,7 +2258,8 @@ public:
         if( op == clang::BO_Assign ) {
             std::string symbol_name = "";
             if( is_read_only(x_lhs, symbol_name) ) {
-                throw std::runtime_error(symbol_name + " is marked as read only.");
+                std::cerr << symbol_name + " is marked as read only." << std::endl;
+                exit(EXIT_FAILURE);
             }
             cast_helper(x_lhs, x_rhs, true);
             ASRUtils::make_ArrayBroadcast_t_util(al, Lloc(x), x_lhs, x_rhs);

--- a/tests/array_01_mdspan.cpp
+++ b/tests/array_01_mdspan.cpp
@@ -1,0 +1,13 @@
+#include <vector>
+#include <mdspan/mdspan.hpp>
+
+int main() {
+
+    std::vector<double> arr1_data = {1.0, 2.0, 3.0, 2.0, 5.0, 7.0, 2.0, 5.0, 7.0};
+
+    Kokkos::mdspan<double, Kokkos::dextents<int32_t, 2>> arr1{arr1_data.data(), 3, 3};
+
+    arr1_data[0] = 4.0;
+
+    return 0;
+}

--- a/tests/array_02_mdspan.cpp
+++ b/tests/array_02_mdspan.cpp
@@ -1,0 +1,31 @@
+#include <vector>
+#include <mdspan/mdspan.hpp>
+
+struct A {
+    std::vector<double> arr1_data;
+};
+
+int main1() {
+
+    std::vector<double> arr2_data = {1.0, 2.0, 3.0, 2.0, 5.0, 7.0, 2.0, 5.0, 7.0};
+    std::vector<double> arr3_data = {1.0, 2.0, 3.0, 2.0, 5.0, 7.0, 2.0, 5.0, 7.0};
+
+    Kokkos::mdspan<double, Kokkos::dextents<int32_t, 2>> arr1{arr2_data.data(), 3, 3};
+
+    arr3_data[0] = 4.0;
+    arr2_data[0] = 4.0;
+
+    return 0;
+}
+
+int main() {
+
+    struct A aobj;
+    aobj.arr1_data = {1.0, 2.0, 3.0, 2.0, 5.0, 7.0, 2.0, 5.0, 7.0};
+
+    Kokkos::mdspan<double, Kokkos::dextents<int32_t, 2>> arr1{aobj.arr1_data.data(), 3, 3};
+
+    aobj.arr1_data[0] = 4.0;
+
+    return 0;
+}

--- a/tests/reference/asr-array_01_mdspan-3a0babe.json
+++ b/tests/reference/asr-array_01_mdspan-3a0babe.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-array_01_mdspan-3a0babe",
+    "cmd": "lc --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/array_01_mdspan.cpp",
+    "infile_hash": "89f0c42a5270d3e994901c745aeb9d6b6d005eb466f53abc3c6b0684",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-array_01_mdspan-3a0babe.stderr",
+    "stderr_hash": "3264f525d743d89d584cc1700c25c652a33211e30d73260d7a885fc1",
+    "returncode": -6
+}

--- a/tests/reference/asr-array_01_mdspan-3a0babe.json
+++ b/tests/reference/asr-array_01_mdspan-3a0babe.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-array_01_mdspan-3a0babe.stderr",
-    "stderr_hash": "3264f525d743d89d584cc1700c25c652a33211e30d73260d7a885fc1",
-    "returncode": -6
+    "stderr_hash": "75fae36610809dcd01894bb09490f3b174e656cf490f47aa38aa5caf",
+    "returncode": 1
 }

--- a/tests/reference/asr-array_01_mdspan-3a0babe.stderr
+++ b/tests/reference/asr-array_01_mdspan-3a0babe.stderr
@@ -1,1 +1,1 @@
-libc++abi: terminating due to uncaught exception of type std::runtime_error: arr1_data is marked as read only.
+arr1_data is marked as read only.

--- a/tests/reference/asr-array_01_mdspan-3a0babe.stderr
+++ b/tests/reference/asr-array_01_mdspan-3a0babe.stderr
@@ -1,0 +1,1 @@
+libc++abi: terminating due to uncaught exception of type std::runtime_error: arr1_data is marked as read only.

--- a/tests/reference/asr-array_02_mdspan-a54a3c5.json
+++ b/tests/reference/asr-array_02_mdspan-a54a3c5.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-array_02_mdspan-a54a3c5",
+    "cmd": "lc --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/array_02_mdspan.cpp",
+    "infile_hash": "0a58aca0631849d0d9f53e91255e409d79d6e8df0db2ce820f0f5d15",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-array_02_mdspan-a54a3c5.stderr",
+    "stderr_hash": "475718d7cd8acad712e80ffc94ff2d8b9904c7971c3b59978ebdce38",
+    "returncode": -6
+}

--- a/tests/reference/asr-array_02_mdspan-a54a3c5.json
+++ b/tests/reference/asr-array_02_mdspan-a54a3c5.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-array_02_mdspan-a54a3c5.stderr",
-    "stderr_hash": "475718d7cd8acad712e80ffc94ff2d8b9904c7971c3b59978ebdce38",
-    "returncode": -6
+    "stderr_hash": "c335fe2f02049228933225c455954d7fb45ed1e5b318fafe53932c96",
+    "returncode": 1
 }

--- a/tests/reference/asr-array_02_mdspan-a54a3c5.stderr
+++ b/tests/reference/asr-array_02_mdspan-a54a3c5.stderr
@@ -1,1 +1,1 @@
-libc++abi: terminating due to uncaught exception of type std::runtime_error: arr2_data is marked as read only.
+arr2_data is marked as read only.

--- a/tests/reference/asr-array_02_mdspan-a54a3c5.stderr
+++ b/tests/reference/asr-array_02_mdspan-a54a3c5.stderr
@@ -1,0 +1,1 @@
+libc++abi: terminating due to uncaught exception of type std::runtime_error: arr2_data is marked as read only.

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -23,6 +23,14 @@ llvm = true
 fortran = true
 
 [[test]]
+filename = "array_01_mdspan.cpp"
+asr = true
+
+[[test]]
+filename = "array_02_mdspan.cpp"
+asr = true
+
+[[test]]
 filename = "../integration_tests/array_01.cpp"
 asr = true
 


### PR DESCRIPTION
https://github.com/lcompilers/lc/issues/14
https://github.com/lcompilers/lc/pull/111#issuecomment-1995995779