### PR TITLE
Initial support for PyTorch C++ API

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,3 +94,5 @@ jobs:
             cp -r $CONDA_PREFIX/lib/python3.12/site-packages/torch/lib/* $CONDA_PREFIX/lib/
             cp -r $CONDA_PREFIX/lib/python3.12/site-packages/torch/share/* $CONDA_PREFIX/share/
             ./integration_tests/run_tests.py -b pytorch
+            export CPATH=$CPATH:$CONDA_PREFIX/include/torch/csrc/api/include
+            ./integration_tests/run_tests.py -b llvmPytorch

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,3 +83,14 @@ jobs:
             export CPATH=$CONDA_PREFIX/include:$CPATH
             ./integration_tests/run_tests.py -b gcc llvm wasm c
             ./integration_tests/run_tests.py -b gcc llvm wasm c -f
+
+      - name: Test4 (Linux)
+        shell: bash -l -e {0}
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+            export CPATH=$CONDA_PREFIX/include:$CPATH
+            conda install --yes pytorch::pytorch
+            cp -r $CONDA_PREFIX/lib/python3.12/site-packages/torch/include/* $CONDA_PREFIX/include/
+            cp -r $CONDA_PREFIX/lib/python3.12/site-packages/torch/lib/* $CONDA_PREFIX/lib/
+            cp -r $CONDA_PREFIX/lib/python3.12/site-packages/torch/share/* $CONDA_PREFIX/share/
+            ./integration_tests/run_tests.py -b pytorch

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -110,6 +110,16 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
             endif()
             set(WASM_EXEC_FLAGS ${WASM_EXEC_FLAGS} "--experimental-wasi-unstable-preview1")
             add_test(${name} ${WASM_EXEC_RUNTIME} ${WASM_EXEC_FLAGS} ${CURRENT_BINARY_DIR}/${name}.js)
+        elseif (LC_BACKEND STREQUAL "pytorch")
+            # PyTorch C++ API testing
+            find_package(Torch REQUIRED)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
+
+            add_executable(${name} ${file_name} ${extra_files})
+            target_link_libraries(${name} "${TORCH_LIBRARIES}")
+            target_compile_options(${name} PUBLIC ${gcc_args})
+            set_property(TARGET ${name} PROPERTY CXX_STANDARD 17)
+            add_test(${name} ${CURRENT_BINARY_DIR}/${name})
         else ()
             add_executable(${name} ${file_name} ${extra_files})
             target_compile_options(${name} PUBLIC ${gcc_args})
@@ -138,7 +148,7 @@ macro(RUN)
                         "${multiValueArgs}" ${ARGN} )
 
     foreach(b ${RUN_LABELS})
-        if (NOT (b MATCHES "^(llvm|llvm2|llvm_rtlib|gcc|c|cpp|x86|wasm|gfortran|llvmImplicit|llvmStackArray|fortran|c_nopragma|llvm_nopragma)$"))
+        if (NOT (b MATCHES "^(llvm|llvm2|llvm_rtlib|gcc|c|cpp|x86|wasm|gfortran|llvmImplicit|llvmStackArray|fortran|c_nopragma|llvm_nopragma|pytorch)$"))
             message(FATAL_ERROR "Unsupported backend: ${b}")
         endif()
     endforeach()
@@ -241,3 +251,5 @@ RUN(NAME vector_02.cpp LABELS gcc llvm)
 RUN(NAME loop_01.cpp LABELS gcc llvm NOFAST)
 
 RUN(NAME test_pkg_lnn_01.cpp LABELS gcc llvm NOFAST)
+
+RUN(NAME pytorch_01.cpp LABELS pytorch)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -84,7 +84,7 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
 
     if (ADD_TEST)
         if ((LC_BACKEND STREQUAL "llvm") OR (LC_BACKEND STREQUAL "cpp") OR (LC_BACKEND STREQUAL "x86")
-                OR (LC_BACKEND STREQUAL "c") OR (LC_BACKEND STREQUAL "fortran"))
+                OR (LC_BACKEND STREQUAL "c") OR (LC_BACKEND STREQUAL "fortran") OR (LC_BACKEND STREQUAL "llvmPytorch"))
             add_custom_command(
                 OUTPUT ${name}.o
                 COMMAND ${LC} -c ${CMAKE_CURRENT_SOURCE_DIR}/${file_name} -o ${name}.o ${extra_args}
@@ -148,7 +148,7 @@ macro(RUN)
                         "${multiValueArgs}" ${ARGN} )
 
     foreach(b ${RUN_LABELS})
-        if (NOT (b MATCHES "^(llvm|llvm2|llvm_rtlib|gcc|c|cpp|x86|wasm|gfortran|llvmImplicit|llvmStackArray|fortran|c_nopragma|llvm_nopragma|pytorch)$"))
+        if (NOT (b MATCHES "^(llvm|llvm2|llvm_rtlib|gcc|c|cpp|x86|wasm|gfortran|llvmImplicit|llvmStackArray|fortran|c_nopragma|llvm_nopragma|pytorch|llvmPytorch)$"))
             message(FATAL_ERROR "Unsupported backend: ${b}")
         endif()
     endforeach()
@@ -252,4 +252,4 @@ RUN(NAME loop_01.cpp LABELS gcc llvm NOFAST)
 
 RUN(NAME test_pkg_lnn_01.cpp LABELS gcc llvm NOFAST)
 
-RUN(NAME pytorch_01.cpp LABELS pytorch)
+RUN(NAME pytorch_01.cpp LABELS pytorch llvmPytorch)

--- a/integration_tests/pytorch_01.cpp
+++ b/integration_tests/pytorch_01.cpp
@@ -1,0 +1,7 @@
+#include <torch/torch.h>
+#include <iostream>
+
+int main() {
+  torch::Tensor tensor = torch::rand({2, 3});
+  std::cout << tensor << std::endl;
+}

--- a/integration_tests/pytorch_01.cpp
+++ b/integration_tests/pytorch_01.cpp
@@ -3,8 +3,8 @@
 
 void check(const torch::Tensor& tensor=torch::empty({1})) {
     float array[5] = {4.0, 2.0, 2.0, 12.0, 2.0};
-    std::cout << tensor << std::endl;
-    if( torch::any(torch::abs(tensor - torch::from_blob(array, {5})) > 1e-6).item<bool>() ) {
+    std::cout << tensor << "\n";
+    if( torch::any(torch::abs(tensor - torch::from_blob(array, {5})) > 1e-8).item<bool>() ) {
       exit(2);
     }
 }
@@ -15,5 +15,5 @@ int main() {
     tensor[3] = 6.0;
     tensor = 2 * tensor;
     check(tensor);
-    std::cout << tensor << std::endl;
+    std::cout << tensor << "\n";
 }

--- a/integration_tests/pytorch_01.cpp
+++ b/integration_tests/pytorch_01.cpp
@@ -1,7 +1,19 @@
 #include <torch/torch.h>
 #include <iostream>
 
+void check(const torch::Tensor& tensor=torch::empty({1})) {
+    float array[5] = {4.0, 2.0, 2.0, 12.0, 2.0};
+    std::cout << tensor << std::endl;
+    if( torch::any(torch::abs(tensor - torch::from_blob(array, {5})) > 1e-6).item<bool>() ) {
+      exit(2);
+    }
+}
+
 int main() {
-  torch::Tensor tensor = torch::rand({2, 3});
-  std::cout << tensor << std::endl;
+    torch::Tensor tensor = torch::ones(5);
+    tensor[0] = 2.0;
+    tensor[3] = 6.0;
+    tensor = 2 * tensor;
+    check(tensor);
+    std::cout << tensor << std::endl;
 }

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -8,7 +8,7 @@ import os
 NO_OF_THREADS = 8 # default no of threads is 8
 SUPPORTED_BACKENDS = ['llvm', 'llvm2', 'llvm_rtlib', 'c', 'cpp', 'x86', 'wasm',
                       'gcc', 'llvmImplicit', 'llvmStackArray', 'fortran',
-                      'c_nopragma', 'llvm_nopragma', 'pytorch']
+                      'c_nopragma', 'llvm_nopragma', 'pytorch', 'llvmPytorch']
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 LC_PATH = f"{BASE_DIR}/../src/bin:$PATH"
 

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -8,7 +8,7 @@ import os
 NO_OF_THREADS = 8 # default no of threads is 8
 SUPPORTED_BACKENDS = ['llvm', 'llvm2', 'llvm_rtlib', 'c', 'cpp', 'x86', 'wasm',
                       'gcc', 'llvmImplicit', 'llvmStackArray', 'fortran',
-                      'c_nopragma', 'llvm_nopragma']
+                      'c_nopragma', 'llvm_nopragma', 'pytorch']
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 LC_PATH = f"{BASE_DIR}/../src/bin:$PATH"
 

--- a/src/lc/clang_ast_to_asr.cpp
+++ b/src/lc/clang_ast_to_asr.cpp
@@ -606,6 +606,8 @@ public:
                     type = ASRUtils::TYPE(ASR::make_Array_t(al, l, ASRUtils::TYPE(ASR::make_Real_t(al, l, 4)),
                         nullptr, 0, ASR::array_physical_typeType::DescriptorArray));
                     return type;
+                } else if( qualified_name == "c10::Scalar" ) {
+                    return nullptr;
                 }
                 throw std::runtime_error(qualified_name + " not defined.");
             }
@@ -1062,7 +1064,8 @@ public:
                 assignment_target = nullptr;
             } else if( ASRUtils::is_complex(*ASRUtils::expr_type(obj)) ||
                        ASR::is_a<ASR::Struct_t>(*ASRUtils::extract_type(
-                        ASRUtils::expr_type(obj))) ) {
+                        ASRUtils::expr_type(obj))) ||
+                       ASR::is_a<ASR::ArrayItem_t>(*obj) ) {
                 TraverseStmt(args[1]);
                 if( !is_stmt_created ) {
                     ASR::expr_t* value = ASRUtils::EXPR(tmp.get());
@@ -2239,10 +2242,10 @@ public:
     void CreateBinOp(ASR::expr_t* lhs, ASR::expr_t* rhs,
         ASR::binopType binop_type, const Location& loc) {
         cast_helper(lhs, rhs, false);
+        ASRUtils::make_ArrayBroadcast_t_util(al, loc, lhs, rhs);
         ASR::ttype_t* result_type = ASRUtils::type_get_past_const(
             ASRUtils::type_get_past_allocatable(
                 ASRUtils::type_get_past_pointer(ASRUtils::expr_type(lhs))));
-        ASRUtils::make_ArrayBroadcast_t_util(al, loc, lhs, rhs);
         if( ASRUtils::is_integer(*ASRUtils::expr_type(lhs)) &&
             ASRUtils::is_integer(*ASRUtils::expr_type(rhs)) ) {
             tmp = ASR::make_IntegerBinOp_t(al, loc, lhs,


### PR DESCRIPTION
LC parses the AST of `integration_tests/pytorch_01.cpp` as follows,

```zsh
|-FunctionDecl 0x13ebd1a78 </Users/czgdp1807/lc_project/lc/integration_tests/pytorch_01.cpp:4:1, line:10:1> line:4:6 used check 'void (const torch::Tensor &)'
| |-ParmVarDecl 0x13ebd16d0 <col:12, col:56> col:33 used tensor 'const torch::Tensor &' cinit
| | `-ExprWithCleanups 0x13ebd1a00 <col:40, col:56> 'const at::Tensor':'const at::Tensor' lvalue
| |   `-MaterializeTemporaryExpr 0x13ebd19e8 <col:40, col:56> 'const at::Tensor':'const at::Tensor' lvalue
| |     `-ImplicitCastExpr 0x13ebd19d0 <col:40, col:56> 'const at::Tensor':'const at::Tensor' <NoOp>
| |       `-CXXBindTemporaryExpr 0x13ebd19b0 <col:40, col:56> 'at::Tensor':'at::Tensor' (CXXTemporary 0x13ebd19b0)
| |         `-CallExpr 0x13ebd1858 <col:40, col:56> 'at::Tensor':'at::Tensor'
| |           |-ImplicitCastExpr 0x13ebd1840 <col:40, col:47> 'at::Tensor (*)(at::IntArrayRef, at::TensorOptions, c10::optional<at::MemoryFormat>)' <FunctionToPointerDecay>
| |           | `-DeclRefExpr 0x13ebd1810 <col:40, col:47> 'at::Tensor (at::IntArrayRef, at::TensorOptions, c10::optional<at::MemoryFormat>)' lvalue Function 0x154f5be28 'empty' 'at::Tensor (at::IntArrayRef, at::TensorOptions, c10::optional<at::MemoryFormat>)'
| |           |-CXXConstructExpr 0x13ebd1938 <col:53, col:55> 'at::IntArrayRef':'c10::ArrayRef<long long>' 'void (const std::initializer_list<long long> &)' list std::initializer_list
| |           | `-MaterializeTemporaryExpr 0x13ebd1920 <col:53, col:55> 'const std::initializer_list<long long>':'const std::initializer_list<long long>' lvalue
| |           |   `-CXXStdInitializerListExpr 0x13ebd1908 <col:53, col:55> 'const std::initializer_list<long long>':'const std::initializer_list<long long>'
| |           |     `-MaterializeTemporaryExpr 0x13ebd18f0 <col:53, col:55> 'const long long[1]' xvalue
| |           |       `-InitListExpr 0x13ebd1890 <col:53, col:55> 'const long long[1]'
| |           |         `-ImplicitCastExpr 0x13ebd18d8 <col:54> 'const long long' <IntegralCast>
| |           |           `-IntegerLiteral 0x13ebd17a8 <col:54> 'int' 1
| |           |-CXXDefaultArgExpr 0x13ebd1968 <<invalid sloc>> 'at::TensorOptions':'c10::TensorOptions'
| |           `-CXXDefaultArgExpr 0x13ebd1988 <<invalid sloc>> 'c10::optional<at::MemoryFormat>':'std::optional<c10::MemoryFormat>'
| `-CompoundStmt 0x13ebd7428 <col:59, line:10:1>
|   |-DeclStmt 0x13ebd1e20 <line:5:5, col:48>
|   | `-VarDecl 0x13ebd1bd0 <col:5, col:47> col:11 used array 'float[5]' cinit
|   |   `-InitListExpr 0x13ebd1d40 <col:22, col:47> 'float[5]'
|   |     |-ImplicitCastExpr 0x13ebd1da8 <col:23> 'float' <FloatingCast>
|   |     | `-FloatingLiteral 0x13ebd1c38 <col:23> 'double' 4.000000e+00
|   |     |-ImplicitCastExpr 0x13ebd1dc0 <col:28> 'float' <FloatingCast>
|   |     | `-FloatingLiteral 0x13ebd1c58 <col:28> 'double' 2.000000e+00
|   |     |-ImplicitCastExpr 0x13ebd1dd8 <col:33> 'float' <FloatingCast>
|   |     | `-FloatingLiteral 0x13ebd1c78 <col:33> 'double' 2.000000e+00
|   |     |-ImplicitCastExpr 0x13ebd1df0 <col:38> 'float' <FloatingCast>
|   |     | `-FloatingLiteral 0x13ebd1c98 <col:38> 'double' 1.200000e+01
|   |     `-ImplicitCastExpr 0x13ebd1e08 <col:44> 'float' <FloatingCast>
|   |       `-FloatingLiteral 0x13ebd1cb8 <col:44> 'double' 2.000000e+00
|   |-CXXOperatorCallExpr 0x13ebd4a10 <line:6:5, col:33> 'ostream':'std::ostream' lvalue '<<'
|   | |-ImplicitCastExpr 0x13ebd49f8 <col:25> 'ostream &(*)(ostream &(*)(ostream &))' <FunctionToPointerDecay>
|   | | `-DeclRefExpr 0x13ebd49d8 <col:25> 'ostream &(ostream &(*)(ostream &))' lvalue CXXMethod 0x128e2bcf0 'operator<<' 'ostream &(ostream &(*)(ostream &))'
|   | |-CXXOperatorCallExpr 0x13ebd3470 <col:5, col:18> 'std::ostream':'std::ostream' lvalue '<<' adl
|   | | |-ImplicitCastExpr 0x13ebd3458 <col:15> 'std::ostream &(*)(std::ostream &, const Tensor &)' <FunctionToPointerDecay>
|   | | | `-DeclRefExpr 0x13ebd33d8 <col:15> 'std::ostream &(std::ostream &, const Tensor &)' lvalue Function 0x14c25cd10 'operator<<' 'std::ostream &(std::ostream &, const Tensor &)'
|   | | |-DeclRefExpr 0x13ebd1e88 <col:5, col:10> 'ostream':'std::ostream' lvalue Var 0x12a69c720 'cout' 'ostream':'std::ostream'
|   | | `-DeclRefExpr 0x13ebd1eb8 <col:18> 'const torch::Tensor':'const at::Tensor' lvalue ParmVar 0x13ebd16d0 'tensor' 'const torch::Tensor &'
|   | `-ImplicitCastExpr 0x13ebd49c0 <col:28, col:33> 'basic_ostream<char, char_traits<char>> &(*)(basic_ostream<char, char_traits<char>> &)' <FunctionToPointerDecay>
|   |   `-DeclRefExpr 0x13ebd4988 <col:28, col:33> 'basic_ostream<char, char_traits<char>> &(basic_ostream<char, char_traits<char>> &)' lvalue Function 0x138b44cd8 'endl' 'basic_ostream<char, char_traits<char>> &(basic_ostream<char, char_traits<char>> &)' (FunctionTemplate 0x128e21290 'endl')
|   `-IfStmt 0x13ebd7408 <line:7:5, line:9:5>
|     |-ExprWithCleanups 0x13ebd7310 <line:7:9, col:89> 'bool':'bool'
|     | `-CXXMemberCallExpr 0x13ebd72d8 <col:9, col:89> 'bool':'bool'
|     |   `-MemberExpr 0x13ebd7260 <col:9, col:87> '<bound member function type>' .item 0x1549c0358
|     |     `-ImplicitCastExpr 0x13ebd72f8 <col:9, col:76> 'const at::Tensor' xvalue <NoOp>
|     |       `-MaterializeTemporaryExpr 0x13ebd7100 <col:9, col:76> 'at::Tensor':'at::Tensor' xvalue
|     |         `-CXXBindTemporaryExpr 0x13ebd70d0 <col:9, col:76> 'at::Tensor':'at::Tensor' (CXXTemporary 0x13ebd70d0)
|     |           `-CallExpr 0x13ebd7070 <col:9, col:76> 'at::Tensor':'at::Tensor'
|     |             |-ImplicitCastExpr 0x13ebd7058 <col:9, col:16> 'at::Tensor (*)(const at::Tensor &)' <FunctionToPointerDecay>
|     |             | `-DeclRefExpr 0x13ebd7000 <col:9, col:16> 'at::Tensor (const at::Tensor &)' lvalue Function 0x14d8f0b08 'any' 'at::Tensor (const at::Tensor &)'
|     |             `-MaterializeTemporaryExpr 0x13ebd70b0 <col:20, col:72> 'const Tensor':'const at::Tensor' lvalue
|     |               `-ImplicitCastExpr 0x13ebd7098 <col:20, col:72> 'const Tensor':'const at::Tensor' <NoOp>
|     |                 `-CXXBindTemporaryExpr 0x13ebd6fe0 <col:20, col:72> 'Tensor':'at::Tensor' (CXXTemporary 0x13ebd6fe0)
|     |                   `-CXXOperatorCallExpr 0x13ebd6fa0 <col:20, col:72> 'Tensor':'at::Tensor' '>' adl
|     |                     |-ImplicitCastExpr 0x13ebd6f88 <col:70> 'Tensor (*)(const Tensor &, const Scalar &)' <FunctionToPointerDecay>
|     |                     | `-DeclRefExpr 0x13ebd6f38 <col:70> 'Tensor (const Tensor &, const Scalar &)' lvalue Function 0x154a07ea8 'operator>' 'Tensor (const Tensor &, const Scalar &)'
|     |                     |-MaterializeTemporaryExpr 0x13ebd6888 <col:20, col:68> 'const at::Tensor':'const at::Tensor' lvalue
|     |                     | `-ImplicitCastExpr 0x13ebd6870 <col:20, col:68> 'const at::Tensor':'const at::Tensor' <NoOp>
|     |                     |   `-CXXBindTemporaryExpr 0x13ebd5bf0 <col:20, col:68> 'at::Tensor':'at::Tensor' (CXXTemporary 0x13ebd5bf0)
|     |                     |     `-CallExpr 0x13ebd5b90 <col:20, col:68> 'at::Tensor':'at::Tensor'
|     |                     |       |-ImplicitCastExpr 0x13ebd5b78 <col:20, col:27> 'at::Tensor (*)(const at::Tensor &)' <FunctionToPointerDecay>
|     |                     |       | `-DeclRefExpr 0x13ebd4ae8 <col:20, col:27> 'at::Tensor (const at::Tensor &)' lvalue Function 0x14d839608 'abs' 'at::Tensor (const at::Tensor &)'
|     |                     |       `-MaterializeTemporaryExpr 0x13ebd5bd0 <col:31, col:67> 'const Tensor':'const at::Tensor' lvalue
|     |                     |         `-ImplicitCastExpr 0x13ebd5bb8 <col:31, col:67> 'const Tensor':'const at::Tensor' <NoOp>
|     |                     |           `-CXXBindTemporaryExpr 0x13ebd5b58 <col:31, col:67> 'Tensor':'at::Tensor' (CXXTemporary 0x13ebd5b58)
|     |                     |             `-CXXOperatorCallExpr 0x13ebd5b18 <col:31, col:67> 'Tensor':'at::Tensor' '-' adl
|     |                     |               |-ImplicitCastExpr 0x13ebd5b00 <col:38> 'Tensor (*)(const Tensor &, const Tensor &)' <FunctionToPointerDecay>
|     |                     |               | `-DeclRefExpr 0x13ebd5ae0 <col:38> 'Tensor (const Tensor &, const Tensor &)' lvalue Function 0x1549f8a00 'operator-' 'Tensor (const Tensor &, const Tensor &)'
|     |                     |               |-DeclRefExpr 0x13ebd4b18 <col:31> 'const torch::Tensor':'const at::Tensor' lvalue ParmVar 0x13ebd16d0 'tensor' 'const torch::Tensor &'
|     |                     |               `-MaterializeTemporaryExpr 0x13ebd5ac8 <col:40, col:67> 'const at::Tensor':'const at::Tensor' lvalue
|     |                     |                 `-ImplicitCastExpr 0x13ebd5ab0 <col:40, col:67> 'const at::Tensor':'const at::Tensor' <NoOp>
|     |                     |                   `-CXXBindTemporaryExpr 0x13ebd4e18 <col:40, col:67> 'at::Tensor':'at::Tensor' (CXXTemporary 0x13ebd4e18)
|     |                     |                     `-CallExpr 0x13ebd4cb0 <col:40, col:67> 'at::Tensor':'at::Tensor'
|     |                     |                       |-ImplicitCastExpr 0x13ebd4c98 <col:40, col:47> 'at::Tensor (*)(void *, at::IntArrayRef, const at::TensorOptions &)' <FunctionToPointerDecay>
|     |                     |                       | `-DeclRefExpr 0x13ebd4c40 <col:40, col:47> 'at::Tensor (void *, at::IntArrayRef, const at::TensorOptions &)' lvalue Function 0x154f1a4a8 'from_blob' 'at::Tensor (void *, at::IntArrayRef, const at::TensorOptions &)'
|     |                     |                       |-ImplicitCastExpr 0x13ebd4d00 <col:57> 'void *' <BitCast>
|     |                     |                       | `-ImplicitCastExpr 0x13ebd4ce8 <col:57> 'float *' <ArrayToPointerDecay>
|     |                     |                       |   `-DeclRefExpr 0x13ebd4bb8 <col:57> 'float[5]' lvalue Var 0x13ebd1bd0 'array' 'float[5]'
|     |                     |                       |-CXXConstructExpr 0x13ebd4dc0 <col:64, col:66> 'at::IntArrayRef':'c10::ArrayRef<long long>' 'void (const std::initializer_list<long long> &)' list std::initializer_list
|     |                     |                       | `-MaterializeTemporaryExpr 0x13ebd4da8 <col:64, col:66> 'const std::initializer_list<long long>':'const std::initializer_list<long long>' lvalue
|     |                     |                       |   `-CXXStdInitializerListExpr 0x13ebd4d90 <col:64, col:66> 'const std::initializer_list<long long>':'const std::initializer_list<long long>'
|     |                     |                       |     `-MaterializeTemporaryExpr 0x13ebd4d78 <col:64, col:66> 'const long long[1]' xvalue
|     |                     |                       |       `-InitListExpr 0x13ebd4d18 <col:64, col:66> 'const long long[1]'
|     |                     |                       |         `-ImplicitCastExpr 0x13ebd4d60 <col:65> 'const long long' <IntegralCast>
|     |                     |                       |           `-IntegerLiteral 0x13ebd4bd8 <col:65> 'int' 5
|     |                     |                       `-CXXDefaultArgExpr 0x13ebd4df0 <<invalid sloc>> 'const at::TensorOptions':'const c10::TensorOptions' lvalue
|     |                     `-MaterializeTemporaryExpr 0x13ebd6f20 <col:72> 'const Scalar':'const c10::Scalar' lvalue
|     |                       `-CXXBindTemporaryExpr 0x13ebd6f00 <col:72> 'const Scalar':'const c10::Scalar' (CXXTemporary 0x13ebd6f00)
|     |                         `-CXXConstructExpr 0x13ebd6ec8 <col:72> 'const Scalar':'const c10::Scalar' 'void (double)'
|     |                           `-FloatingLiteral 0x13ebd5c10 <col:72> 'double' 1.000000e-06
|     `-CompoundStmt 0x13ebd73f0 <col:93, line:9:5>
|       `-CallExpr 0x13ebd73c8 <line:8:7, col:13> 'void'
|         |-ImplicitCastExpr 0x13ebd73b0 <col:7> 'void (*)(int) __attribute__((noreturn))' <FunctionToPointerDecay>
|         | `-DeclRefExpr 0x13ebd7390 <col:7> 'void (int) __attribute__((noreturn))' lvalue Function 0x141218db8 'exit' 'void (int) __attribute__((noreturn))'
|         `-IntegerLiteral 0x13ebd7370 <col:12> 'int' 2
`-FunctionDecl 0x13ebd7478 <line:12:1, line:19:1> line:12:5 main 'int ()'
  `-CompoundStmt 0x13ebde810 <col:12, line:19:1>
    |-DeclStmt 0x13ebd8698 <line:13:5, col:42>
    | `-VarDecl 0x13ebd75c8 <col:5, col:41> col:19 used tensor 'torch::Tensor':'at::Tensor' cinit destroyed
    |   `-ExprWithCleanups 0x13ebd8680 <col:28, col:41> 'at::Tensor':'at::Tensor'
    |     `-CXXBindTemporaryExpr 0x13ebd8660 <col:28, col:41> 'at::Tensor':'at::Tensor' (CXXTemporary 0x13ebd8660)
    |       `-CallExpr 0x13ebd7e60 <col:28, col:41> 'at::Tensor':'at::Tensor'
    |         |-ImplicitCastExpr 0x13ebd7e48 <col:28, col:35> 'at::Tensor (*)(at::IntArrayRef, at::TensorOptions)' <FunctionToPointerDecay>
    |         | `-DeclRefExpr 0x13ebd7df0 <col:28, col:35> 'at::Tensor (at::IntArrayRef, at::TensorOptions)' lvalue Function 0x155057e08 'ones' 'at::Tensor (at::IntArrayRef, at::TensorOptions)'
    |         |-ImplicitCastExpr 0x13ebd8620 <col:40> 'at::IntArrayRef':'c10::ArrayRef<long long>' <ConstructorConversion>
    |         | `-CXXConstructExpr 0x13ebd85f0 <col:40> 'at::IntArrayRef':'c10::ArrayRef<long long>' 'void (const long long &)'
    |         |   `-MaterializeTemporaryExpr 0x13ebd85d8 <col:40> 'const long long':'const long long' lvalue
    |         |     `-ImplicitCastExpr 0x13ebd85c0 <col:40> 'const long long':'const long long' <IntegralCast>
    |         |       `-IntegerLiteral 0x13ebd76a0 <col:40> 'int' 5
    |         `-CXXDefaultArgExpr 0x13ebd8638 <<invalid sloc>> 'at::TensorOptions':'c10::TensorOptions'
    |-ExprWithCleanups 0x13ebd9ac8 <line:14:5, col:17> 'Tensor':'at::Tensor' lvalue
    | `-CXXOperatorCallExpr 0x13ebd9a90 <col:5, col:17> 'Tensor':'at::Tensor' lvalue '='
    |   |-ImplicitCastExpr 0x13ebd9a78 <col:15> 'Tensor &(*)(const Scalar &) &&' <FunctionToPointerDecay>
    |   | `-DeclRefExpr 0x13ebd9a58 <col:15> 'Tensor &(const Scalar &) &&' lvalue CXXMethod 0x149f2d3f0 'operator=' 'Tensor &(const Scalar &) &&'
    |   |-MaterializeTemporaryExpr 0x13ebd9a40 <col:5, col:13> 'Tensor':'at::Tensor' xvalue
    |   | `-CXXBindTemporaryExpr 0x13ebd8d98 <col:5, col:13> 'Tensor':'at::Tensor' (CXXTemporary 0x13ebd8d98)
    |   |   `-CXXOperatorCallExpr 0x13ebd8d58 <col:5, col:13> 'Tensor':'at::Tensor' '[]'
    |   |     |-ImplicitCastExpr 0x13ebd8d40 <col:11, col:13> 'Tensor (*)(int64_t) const' <FunctionToPointerDecay>
    |   |     | `-DeclRefExpr 0x13ebd8d20 <col:11, col:13> 'Tensor (int64_t) const' lvalue CXXMethod 0x149f311c8 'operator[]' 'Tensor (int64_t) const'
    |   |     |-ImplicitCastExpr 0x13ebd8cf0 <col:5> 'const at::Tensor' lvalue <NoOp>
    |   |     | `-DeclRefExpr 0x13ebd86b0 <col:5> 'torch::Tensor':'at::Tensor' lvalue Var 0x13ebd75c8 'tensor' 'torch::Tensor':'at::Tensor'
    |   |     `-ImplicitCastExpr 0x13ebd8d08 <col:12> 'int64_t':'long long' <IntegralCast>
    |   |       `-IntegerLiteral 0x13ebd86d0 <col:12> 'int' 0
    |   `-MaterializeTemporaryExpr 0x13ebd9a28 <col:17> 'const Scalar':'const c10::Scalar' lvalue
    |     `-CXXBindTemporaryExpr 0x13ebd9a08 <col:17> 'const Scalar':'const c10::Scalar' (CXXTemporary 0x13ebd9a08)
    |       `-CXXConstructExpr 0x13ebd99d0 <col:17> 'const Scalar':'const c10::Scalar' 'void (double)'
    |         `-FloatingLiteral 0x13ebd8db8 <col:17> 'double' 2.000000e+00
    |-ExprWithCleanups 0x13ebdaef8 <line:15:5, col:17> 'Tensor':'at::Tensor' lvalue
    | `-CXXOperatorCallExpr 0x13ebdaec0 <col:5, col:17> 'Tensor':'at::Tensor' lvalue '='
    |   |-ImplicitCastExpr 0x13ebdaea8 <col:15> 'Tensor &(*)(const Scalar &) &&' <FunctionToPointerDecay>
    |   | `-DeclRefExpr 0x13ebdae88 <col:15> 'Tensor &(const Scalar &) &&' lvalue CXXMethod 0x149f2d3f0 'operator=' 'Tensor &(const Scalar &) &&'
    |   |-MaterializeTemporaryExpr 0x13ebdae70 <col:5, col:13> 'Tensor':'at::Tensor' xvalue
    |   | `-CXXBindTemporaryExpr 0x13ebda1c8 <col:5, col:13> 'Tensor':'at::Tensor' (CXXTemporary 0x13ebda1c8)
    |   |   `-CXXOperatorCallExpr 0x13ebda188 <col:5, col:13> 'Tensor':'at::Tensor' '[]'
    |   |     |-ImplicitCastExpr 0x13ebda170 <col:11, col:13> 'Tensor (*)(int64_t) const' <FunctionToPointerDecay>
    |   |     | `-DeclRefExpr 0x13ebda150 <col:11, col:13> 'Tensor (int64_t) const' lvalue CXXMethod 0x149f311c8 'operator[]' 'Tensor (int64_t) const'
    |   |     |-ImplicitCastExpr 0x13ebda120 <col:5> 'const at::Tensor' lvalue <NoOp>
    |   |     | `-DeclRefExpr 0x13ebd9ae0 <col:5> 'torch::Tensor':'at::Tensor' lvalue Var 0x13ebd75c8 'tensor' 'torch::Tensor':'at::Tensor'
    |   |     `-ImplicitCastExpr 0x13ebda138 <col:12> 'int64_t':'long long' <IntegralCast>
    |   |       `-IntegerLiteral 0x13ebd9b00 <col:12> 'int' 3
    |   `-MaterializeTemporaryExpr 0x13ebdae58 <col:17> 'const Scalar':'const c10::Scalar' lvalue
    |     `-CXXBindTemporaryExpr 0x13ebdae38 <col:17> 'const Scalar':'const c10::Scalar' (CXXTemporary 0x13ebdae38)
    |       `-CXXConstructExpr 0x13ebdae00 <col:17> 'const Scalar':'const c10::Scalar' 'void (double)'
    |         `-FloatingLiteral 0x13ebda1e8 <col:17> 'double' 6.000000e+00
    |-ExprWithCleanups 0x13ebdbd48 <line:16:5, col:18> 'Tensor':'at::Tensor' lvalue
    | `-CXXOperatorCallExpr 0x13ebdbce0 <col:5, col:18> 'Tensor':'at::Tensor' lvalue '='
    |   |-ImplicitCastExpr 0x13ebdbcc8 <col:12> 'Tensor &(*)(Tensor &&) & noexcept' <FunctionToPointerDecay>
    |   | `-DeclRefExpr 0x13ebdbca8 <col:12> 'Tensor &(Tensor &&) & noexcept' lvalue CXXMethod 0x149f2d188 'operator=' 'Tensor &(Tensor &&) & noexcept'
    |   |-DeclRefExpr 0x13ebdaf10 <col:5> 'torch::Tensor':'at::Tensor' lvalue Var 0x13ebd75c8 'tensor' 'torch::Tensor':'at::Tensor'
    |   `-MaterializeTemporaryExpr 0x13ebdbc90 <col:14, col:18> 'Tensor':'at::Tensor' xvalue
    |     `-CXXBindTemporaryExpr 0x13ebdbc70 <col:14, col:18> 'Tensor':'at::Tensor' (CXXTemporary 0x13ebdbc70)
    |       `-CXXOperatorCallExpr 0x13ebdbc30 <col:14, col:18> 'Tensor':'at::Tensor' '*' adl
    |         |-ImplicitCastExpr 0x13ebdbc18 <col:16> 'Tensor (*)(const Scalar &, const Tensor &)' <FunctionToPointerDecay>
    |         | `-DeclRefExpr 0x13ebdbbf8 <col:16> 'Tensor (const Scalar &, const Tensor &)' lvalue Function 0x1549f86a8 'operator*' 'Tensor (const Scalar &, const Tensor &)'
    |         |-MaterializeTemporaryExpr 0x13ebdbbc8 <col:14> 'const Scalar':'const c10::Scalar' lvalue
    |         | `-CXXBindTemporaryExpr 0x13ebdbba8 <col:14> 'const Scalar':'const c10::Scalar' (CXXTemporary 0x13ebdbba8)
    |         |   `-CXXConstructExpr 0x13ebdbb70 <col:14> 'const Scalar':'const c10::Scalar' 'void (int)'
    |         |     `-IntegerLiteral 0x13ebdaf30 <col:14> 'int' 2
    |         `-ImplicitCastExpr 0x13ebdbbe0 <col:18> 'const Tensor':'const at::Tensor' lvalue <NoOp>
    |           `-DeclRefExpr 0x13ebdaf50 <col:18> 'torch::Tensor':'at::Tensor' lvalue Var 0x13ebd75c8 'tensor' 'torch::Tensor':'at::Tensor'
    |-CallExpr 0x13ebdbe30 <line:17:5, col:17> 'void'
    | |-ImplicitCastExpr 0x13ebdbe18 <col:5> 'void (*)(const torch::Tensor &)' <FunctionToPointerDecay>
    | | `-DeclRefExpr 0x13ebdbdc8 <col:5> 'void (const torch::Tensor &)' lvalue Function 0x13ebd1a78 'check' 'void (const torch::Tensor &)'
    | `-ImplicitCastExpr 0x13ebdbe58 <col:11> 'const torch::Tensor':'const at::Tensor' lvalue <NoOp>
    |   `-DeclRefExpr 0x13ebdbda8 <col:11> 'torch::Tensor':'at::Tensor' lvalue Var 0x13ebd75c8 'tensor' 'torch::Tensor':'at::Tensor'
    `-CXXOperatorCallExpr 0x13ebde7d8 <line:18:5, col:33> 'ostream':'std::ostream' lvalue '<<'
      |-ImplicitCastExpr 0x13ebde7c0 <col:25> 'ostream &(*)(ostream &(*)(ostream &))' <FunctionToPointerDecay>
      | `-DeclRefExpr 0x13ebde7a0 <col:25> 'ostream &(ostream &(*)(ostream &))' lvalue CXXMethod 0x128e2bcf0 'operator<<' 'ostream &(ostream &(*)(ostream &))'
      |-CXXOperatorCallExpr 0x13ebdd238 <col:5, col:18> 'std::ostream':'std::ostream' lvalue '<<' adl
      | |-ImplicitCastExpr 0x13ebdd220 <col:15> 'std::ostream &(*)(std::ostream &, const Tensor &)' <FunctionToPointerDecay>
      | | `-DeclRefExpr 0x13ebdd200 <col:15> 'std::ostream &(std::ostream &, const Tensor &)' lvalue Function 0x14c25cd10 'operator<<' 'std::ostream &(std::ostream &, const Tensor &)'
      | |-DeclRefExpr 0x13ebdbec0 <col:5, col:10> 'ostream':'std::ostream' lvalue Var 0x12a69c720 'cout' 'ostream':'std::ostream'
      | `-ImplicitCastExpr 0x13ebdd1e8 <col:18> 'const Tensor':'const at::Tensor' lvalue <NoOp>
      |   `-DeclRefExpr 0x13ebdbef0 <col:18> 'torch::Tensor':'at::Tensor' lvalue Var 0x13ebd75c8 'tensor' 'torch::Tensor':'at::Tensor'
      `-ImplicitCastExpr 0x13ebde788 <col:28, col:33> 'basic_ostream<char, char_traits<char>> &(*)(basic_ostream<char, char_traits<char>> &)' <FunctionToPointerDecay>
        `-DeclRefExpr 0x13ebde750 <col:28, col:33> 'basic_ostream<char, char_traits<char>> &(basic_ostream<char, char_traits<char>> &)' lvalue Function 0x138b44cd8 'endl' 'basic_ostream<char, char_traits<char>> &(basic_ostream<char, char_traits<char>> &)' (FunctionTemplate 0x128e21290 'endl')
```